### PR TITLE
FEAT & REFACTOR : 날짜와 검색 컬럼을 통해 엑셀 데이터 조회 및 dto 값 유효성 검사

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,18 @@
         </dependency>
 
         <!-- hibernate type -->
-		<dependency>
-			<groupId>com.vladmihalcea</groupId>
-			<artifactId>hibernate-types-52</artifactId>
-			<version>2.14.0</version>
-		</dependency>
+        <dependency>
+            <groupId>com.vladmihalcea</groupId>
+            <artifactId>hibernate-types-52</artifactId>
+            <version>2.14.0</version>
+        </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-validation -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <version>2.6.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
@@ -3,6 +3,8 @@ package com.piaar_erp.erp_api.domain.erp_order_item.controller;
 import java.util.List;
 import java.util.Map;
 
+import javax.validation.Valid;
+
 import com.piaar_erp.erp_api.domain.erp_order_item.dto.ErpOrderItemDto;
 import com.piaar_erp.erp_api.domain.erp_order_item.service.ErpOrderItemBusinessService;
 import com.piaar_erp.erp_api.domain.message.dto.Message;
@@ -10,6 +12,7 @@ import com.piaar_erp.erp_api.domain.message.dto.Message;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/erp-order-item")
 public class ErpOrderItemApi {
@@ -63,10 +67,10 @@ public class ErpOrderItemApi {
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see erpOrderItemBusinessService#saveList
+     * @see ErpOrderItemBusinessService#saveList
      */
     @PostMapping("/list")
-    public ResponseEntity<?> saveList(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    public ResponseEntity<?> saveList(@RequestBody @Valid List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
         erpOrderItemBusinessService.saveList(itemDtos);

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/dto/ErpOrderItemDto.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/dto/ErpOrderItemDto.java
@@ -3,7 +3,16 @@ package com.piaar_erp.erp_api.domain.erp_order_item.dto;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
+
 import com.piaar_erp.erp_api.domain.erp_order_item.entity.ErpOrderItemEntity;
+
+import org.hibernate.validator.constraints.Length;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,51 +32,140 @@ import lombok.experimental.Accessors;
 public class ErpOrderItemDto {
     private Integer cid;
     private UUID id;
-    private UUID uniqueCode;      // 피아르 고유코드
+    
+    @Size(max = 36)
+    private String uniqueCode;      // 피아르 고유코드
+
+    @Size(max = 36)
     private String orderNumber1;        // 주문번호1
+    
+    @Size(max = 36)
     private String orderNumber2;        // 주문번호2
+
+    @Size(max = 36)
     private String orderNumber3;        // 주문번호3
+
+    @Size(max = 300)
     private String prodName;        // 상품명 / 필수값
+    
+    @Size(max = 300)
     private String optionName;      // 옵션명 / 필수값
+
+    @PositiveOrZero
     private Integer unit;       // 수량 / 필수값
+    
+    @Size(max = 20)
     private String receiver;        // 수취인명 / 필수값
+
+    @Size(max = 20)
     private String receiverContact1;        // 전화번호1 / 필수값
+
+    @Size(max = 20)
     private String receiverContact2;        // 전화번호2
+
+    @Size(max = 200)
     private String destination;     // 주소 / 필수값
+
+    @Size(max = 10)
     private String zipCode;     // 우편번호
+
+    @Size(max = 45)
     private String transportType;       // 배송방식
+
+    @Size(max = 200)
     private String deliveryMessage;     // 배송메세지
+
+    @Size(max = 36)
     private String prodUniqueNumber1;       // 상품고유번호1
+
+    @Size(max = 36)
     private String prodUniqueNumber2;       // 상품고유번호2
+
+    @Size(max = 36)
     private String optionUniqueNumber1;     // 옵션고유번호1
+
+    @Size(max = 36)
     private String optionUniqueNumber2;     // 옵션고유번호2
+
+    @Size(max = 20)
     private String prodCode;        // 피아르 상품코드
+
+    @Size(max = 20)
     private String optionCode;      // 피아르 옵션코드
+
+    @Size(max = 200)
     private String managementMemo1;     // 관리메모1
+
+    @Size(max = 200)
     private String managementMemo2;     // 관리메모2
+
+    @Size(max = 200)
     private String managementMemo3;     // 관리메모3
+
+    @Size(max = 200)
     private String managementMemo4;     // 관리메모4
+
+    @Size(max = 200)
     private String managementMemo5;     // 관리메모5
+    
+    @Size(max = 200)
     private String managementMemo6;     // 관리메모6
+    
+    @Size(max = 200)
     private String managementMemo7;     // 관리메모7
+    
+    @Size(max = 200)
     private String managementMemo8;     // 관리메모8
+    
+    @Size(max = 200)
     private String managementMemo9;     // 관리메모9
+    
+    @Size(max = 200)
     private String managementMemo10;     // 관리메모10
+    
+    @Size(max = 200)
     private String managementMemo11;     // 관리메모11
+    
+    @Size(max = 200)
     private String managementMemo12;     // 관리메모12
+    
+    @Size(max = 200)
     private String managementMemo13;     // 관리메모13
+    
+    @Size(max = 200)
     private String managementMemo14;     // 관리메모14
+    
+    @Size(max = 200)
     private String managementMemo15;     // 관리메모15
+    
+    @Size(max = 200)
     private String managementMemo16;     // 관리메모16
+    
+    @Size(max = 200)
     private String managementMemo17;     // 관리메모17
+    
+    @Size(max = 200)
     private String managementMemo18;     // 관리메모18
+    
+    @Size(max = 200)
     private String managementMemo19;     // 관리메모19
+    
+    @Size(max = 200)
     private String managementMemo20;     // 관리메모20
+    
+    @Size(max = 1)
     private String salesYn;
+    
     private LocalDateTime salesAt;
+    
+    @Size(max = 1)
     private String releaseYn;
+    
     private LocalDateTime releaseAt;
+    
+    @Size(max = 1)
     private String stockReflectYn;
+    
     private LocalDateTime createdAt;
     private UUID createdBy;
 

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/entity/ErpOrderItemEntity.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/entity/ErpOrderItemEntity.java
@@ -41,9 +41,8 @@ public class ErpOrderItemEntity {
     @Column(name = "id")
     private UUID id;
 
-    @Type(type = "uuid-char")
     @Column(name = "unique_code")
-    private UUID uniqueCode; // 피아르 고유코드
+    private String uniqueCode; // 피아르 고유코드
 
     @Column(name = "order_number1")
     private String orderNumber1; // 주문번호1

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemBusinessService.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemBusinessService.java
@@ -194,7 +194,7 @@ public class ErpOrderItemBusinessService {
             }
 
             ErpOrderItemVo excelVo = ErpOrderItemVo.builder()
-                    .uniqueCode(UUID.randomUUID())
+                    .uniqueCode(UUID.randomUUID().toString())
                     .orderNumber1(row.getCell(1) != null ? row.getCell(1).getStringCellValue() : "")
                     .orderNumber2(row.getCell(2) != null ? row.getCell(2).getStringCellValue() : "")
                     .orderNumber3(row.getCell(3) != null ? row.getCell(3).getStringCellValue() : "")
@@ -247,7 +247,7 @@ public class ErpOrderItemBusinessService {
         List<ErpOrderItemEntity> orderItemEntities = orderItemDtos.stream()
                 .map(r -> {
                     r.setId(UUID.randomUUID())
-                            .setUniqueCode(UUID.randomUUID())
+                            .setUniqueCode(UUID.randomUUID().toString())
                             .setSalesYn("n")
                             .setReleaseYn("n")
                             .setStockReflectYn("n")

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemService.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemService.java
@@ -1,6 +1,5 @@
 package com.piaar_erp.erp_api.domain.erp_order_item.service;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/vo/ErpOrderItemVo.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/vo/ErpOrderItemVo.java
@@ -18,7 +18,7 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 public class ErpOrderItemVo {
     private UUID id;
-    private UUID uniqueCode;      // 피아르 고유코드
+    private String uniqueCode;      // 피아르 고유코드
     private String orderNumber1;        // 주문번호1
     private String orderNumber2;        // 주문번호2
     private String orderNumber3;        // 주문번호3
@@ -73,7 +73,6 @@ public class ErpOrderItemVo {
     private String stockReflectYn;
     private LocalDateTime createdAt;
     private UUID createdBy;
-    private Integer deliveryReadyFileCid;
 
     public static ErpOrderItemVo toVo(ErpOrderItemProj proj) {
         ErpOrderItemVo itemVo = ErpOrderItemVo.builder()

--- a/src/main/java/com/piaar_erp/erp_api/domain/exception/controller/GlobalCustomExceptionHandler.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/exception/controller/GlobalCustomExceptionHandler.java
@@ -1,0 +1,61 @@
+package com.piaar_erp.erp_api.domain.exception.controller;
+
+import com.piaar_erp.erp_api.domain.exception.CustomAccessDeniedException;
+import com.piaar_erp.erp_api.domain.exception.CustomExcelFileUploadException;
+import com.piaar_erp.erp_api.domain.exception.CustomNotFoundDataException;
+import com.piaar_erp.erp_api.domain.message.dto.Message;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalCustomExceptionHandler {
+    @ExceptionHandler({ CustomExcelFileUploadException.class })
+    public ResponseEntity<?> customExcelFileUploadExceptionHandler(CustomExcelFileUploadException e) {
+        log.error("ERROR STACKTRACE => {}", e.getStackTrace());
+
+        Message message = new Message();
+        message.setStatus(HttpStatus.BAD_REQUEST);
+        message.setMessage("data_error");
+        message.setMemo(e.getMessage());
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    /**
+     * 유저 접근 권한이 없을때
+     * http status 403
+     */
+    @ExceptionHandler({ CustomAccessDeniedException.class })
+    public ResponseEntity<?> customAccessDeniedExceptionHandler(CustomAccessDeniedException e) {
+        log.error("ERROR STACKTRACE => {}", e.getStackTrace());
+
+        Message message = new Message();
+        message.setStatus(HttpStatus.FORBIDDEN);
+        message.setMessage("access_denied");
+        message.setMemo(e.getMessage());
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    /**
+     * 데이터를 찾을 수 없을 때
+     * http status 403
+     */
+    @ExceptionHandler({ CustomNotFoundDataException.class })
+    public ResponseEntity<?> customNotFoundExceptionHandler(CustomNotFoundDataException e) {
+        log.error("ERROR STACKTRACE => {}", e.getStackTrace());
+
+        Message message = new Message();
+        message.setStatus(HttpStatus.NOT_FOUND);
+        message.setMessage("not_found");
+        message.setMemo(e.getMessage());
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+}

--- a/src/main/java/com/piaar_erp/erp_api/domain/exception/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/exception/controller/GlobalExceptionHandler.java
@@ -1,62 +1,50 @@
 package com.piaar_erp.erp_api.domain.exception.controller;
 
-import com.piaar_erp.erp_api.domain.exception.CustomAccessDeniedException;
-import com.piaar_erp.erp_api.domain.exception.CustomExcelFileUploadException;
-import com.piaar_erp.erp_api.domain.exception.CustomNotFoundDataException;
-import com.piaar_erp.erp_api.domain.message.dto.Message;
+import javax.validation.ConstraintViolationException;
 
+import com.piaar_erp.erp_api.domain.message.dto.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import lombok.extern.slf4j.Slf4j;
-
 @ControllerAdvice
 @Slf4j
-
 public class GlobalExceptionHandler {
-    @ExceptionHandler({ CustomExcelFileUploadException.class })
-    public ResponseEntity<?> CustomDeliveryReadyExceptionHandler(CustomExcelFileUploadException e) {
-        log.error("ERROR STACKTRACE => {}", e.getStackTrace());
 
-        Message message = new Message();
-        message.setStatus(HttpStatus.BAD_REQUEST);
-        message.setMessage("data_error");
-        message.setMemo(e.getMessage());
+   /**
+    * 데이터 베이스 Valid 유효성 검사 예외가 발생했을 때
+    * http status 409
+    */
+   @ExceptionHandler({ ConstraintViolationException.class })
+   public ResponseEntity<?> constraintViolationExceptionHandler(ConstraintViolationException e) {
+       log.error("ERROR STACKTRACE => {}", e.getStackTrace());
 
-        return new ResponseEntity<>(message, message.getStatus());
-    }
+       Message message = new Message();
+       message.setStatus(HttpStatus.CONFLICT);
+       message.setMessage("data_error");
+       message.setMemo("입력된 데이터를 등록할 수 없습니다.\n 수정 후 재등록해주세요.");
 
-    /**
-     * 유저 접근 권한이 없을때
-     * http status 403
-     */
-    @ExceptionHandler({ CustomAccessDeniedException.class })
-    public ResponseEntity<?> CustomAccessDeniedExceptionHandler(CustomAccessDeniedException e) {
-        log.error("ERROR STACKTRACE => {}", e.getStackTrace());
+       return new ResponseEntity<>(message, message.getStatus());
+   }
 
-        Message message = new Message();
-        message.setStatus(HttpStatus.FORBIDDEN);
-        message.setMessage("access_denied");
-        message.setMemo(e.getMessage());
+   /**
+    * 데이터 베이스 관련 예외가 발생했을 때
+    * http status 400
+    */
+   @ExceptionHandler({ DataAccessException.class })
+   public ResponseEntity<?> dataAccessExceptionHandler(DataAccessException e) {
+       log.error("ERROR STACKTRACE => {}", e.getStackTrace());
+       log.error("ERROR ROOTCAUSE => {}", e.getRootCause());
 
-        return new ResponseEntity<>(message, message.getStatus());
-    }
+       Message message = new Message();
+       message.setStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+       message.setMessage("undefined_error");
+       message.setMemo("알 수 없는 에러가 발생했습니다. 관리자에게 문의하세요.");
 
-    /**
-     * 데이터를 찾을 수 없을 때
-     * http status 403
-     */
-    @ExceptionHandler({ CustomNotFoundDataException.class })
-    public ResponseEntity<?> CustomNotFoundExceptionHandler(CustomNotFoundDataException e) {
-        log.error("ERROR STACKTRACE => {}", e.getStackTrace());
-
-        Message message = new Message();
-        message.setStatus(HttpStatus.NOT_FOUND);
-        message.setMessage("not_found");
-        message.setMemo(e.getMessage());
-
-        return new ResponseEntity<>(message, message.getStatus());
-    }
+       return new ResponseEntity<>(message, message.getStatus());
+   }
 }

--- a/src/test/java/com/piaar_erp/erp_api/service/ErpOrderItemServiceTest.java
+++ b/src/test/java/com/piaar_erp/erp_api/service/ErpOrderItemServiceTest.java
@@ -1,0 +1,53 @@
+package com.piaar_erp.erp_api.service;
+
+import com.piaar_erp.erp_api.domain.erp_order_item.entity.ErpOrderItemEntity;
+import com.piaar_erp.erp_api.domain.erp_order_item.repository.ErpOrderItemRepository;
+import com.piaar_erp.erp_api.utils.CustomDateUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@WebAppConfiguration
+@Transactional
+public class ErpOrderItemServiceTest {
+
+    @Autowired
+    private ErpOrderItemRepository erpOrderItemRepository;
+
+//    @Test
+//    public void 엑셀데이터_생성() throws DataIntegrityViolationException {
+//        UUID userId = UUID.fromString("#USER_ID#");
+//        UUID itemId = UUID.randomUUID();
+//
+//        ErpOrderItemEntity erpOrderItemEntity = ErpOrderItemEntity.builder()
+//                .cid(1)
+//                .id(itemId)
+//                .receiver("이름이 아주 긴 수취인의 이름입니다. 이름이 길어서 데이터베이스에 저장할 수 없습니다.")
+//                .salesYn("n")
+//                .releaseYn("n")
+//                .stockReflectYn("n")
+//                .createdAt(CustomDateUtils.getCurrentDateTime())
+//                .createdBy(userId)
+//                .build();
+//
+//        assertThrows(DataIntegrityViolationException.class, () -> {
+//            ErpOrderItemEntity savedEntity = erpOrderItemRepository.save(erpOrderItemEntity);
+//
+//        });
+//
+//        System.out.println("##### ErpOrderItemServiceTest.엑셀데이터_생성 성공 #####");
+//    }
+}


### PR DESCRIPTION
#### [ 변경사항 ]

1)
* 엑셀 데이터 저장 시 dto값 크기 검사를 진행했습니다. ex) varchar(20)은 사이즈를 20으로 제한
* uniqueCode값을 UUID에서 String으로 변경했습니다.
* query dsl로 날짜범위 내의 데이터 조회, 특정 컬럼에 특정값이 포함되어 있는지 확인해 조회하는 기능을 추가했습니다.
* GlobalExceptionHandler => DataAccessException을 전역 예외처리했습니다.

-----

#### [ 요청사항 ]

1)
* 날짜 범위 내의 데이터 조회 쿼리는 테스트 필요합니다. Get : /api/v1/erp-order-item/list 확인후 업데이트 부탁드립니다~
* ErpOrderItemDto에서 사이즈 검사한 부분도 확인부탁드립니다.

-----