### PR TITLE
FEAT : 합배송 처리 시 합병데이터 나열 여부를 확인해 반환해주는 기능을 구현하자

### DIFF
--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
@@ -185,6 +185,7 @@ public class ErpOrderItemApi {
      * <p>
      * <b>POST : API URL => /api/v1/erp-order-item/combined</b>
      * 
+     * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
      * @see ErpOrderItemBusinessService#getCombinedDelivery
      */
@@ -193,6 +194,26 @@ public class ErpOrderItemApi {
         Message message = new Message();
 
         message.setData(erpOrderItemBusinessService.getCombinedDelivery(itemDtos));
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    /**
+     * Get merged combined delivery item of erp order item.
+     * <p>
+     * <b>POST : API URL => /api/v1/erp-order-item/combined/merge</b>
+     * 
+     * @param itemDtos : List::ErpOrderItemDto::
+     * @return ResponseEntity(message, HttpStatus)
+     * @see ErpOrderItemBusinessService#getMergeCombinedDelivery
+     */
+    @PostMapping("/combined/merge")
+    public ResponseEntity<?> getMergeCombinedDelivery(@RequestBody List<ErpOrderItemDto> itemDtos) {
+        Message message = new Message();
+
+        message.setData(erpOrderItemBusinessService.getMergeCombinedDelivery(itemDtos));
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/repository/ErpOrderItemRepositoryImpl.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/repository/ErpOrderItemRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.piaar_erp.erp_api.domain.erp_order_item.repository;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -91,12 +92,13 @@ public class ErpOrderItemRepositoryImpl implements ErpOrderItemRepositoryCustom 
     }
 
     private BooleanExpression withinDateRange(Map<String, Object> params) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         LocalDateTime startDate = null;
         LocalDateTime endDate = null;
         
         if (params.get("startDate") != null && params.get("endDate") != null) {
-            startDate = LocalDateTime.parse(params.get("startDate").toString());
-            endDate = LocalDateTime.parse(params.get("endDate").toString());
+            startDate = LocalDateTime.parse(params.get("startDate").toString(), formatter);
+            endDate = LocalDateTime.parse(params.get("endDate").toString(), formatter);
 
             return qErpOrderItemEntity.createdAt.between(startDate, endDate);
         } else {

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/vo/ErpOrderItemVo.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/vo/ErpOrderItemVo.java
@@ -64,7 +64,7 @@ public class ErpOrderItemVo {
     private String prodManagementName;
     private String optionDefaultName;
     private String optionManagementName;
-    private Integer optionStockUnit;
+    private String optionStockUnit;
 
     private String salesYn;
     private LocalDateTime salesAt;


### PR DESCRIPTION
#### [ 변경사항 ]

1)
* 합배송 처리 - '주문자 정보+상품명+옵션명' 중복된다면 수량을 플러스시키는 기능 추가
* 합배송 처리 시 주문 헤더의 mergeYn에 따라 합병데이터 나열 여부를 처리
* [ErpOrderItemRepositoryImpl : withinDateRange] 날짜 조회시 DateFormatter 사용해 format을 변경하도록 수정

-----

#### [ 요청사항 ]

1)
* 현재 합배송 처리는 **주문 헤더**에만 적용되는 기능입니다. (판매헤더, 출고 헤더 등 에도 필요한 기능일 것 같아요.)
* 합배송 처리 메서드명 확인 부탁드립니다~ (현재 getMergeCombinedDelivery)

-----