### PR TITLE
FEAT

### DIFF
--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Validated
 @RestController
-@RequestMapping("/api/v1/erp-order-item")
+@RequestMapping("/api/v1/erp-order-items")
 public class ErpOrderItemApi {
     private ErpOrderItemBusinessService erpOrderItemBusinessService;
 
@@ -37,13 +37,10 @@ public class ErpOrderItemApi {
     /**
      * Upload excel data for order excel.
      * <p>
-     * <b>POST : API URL => /api/v1/erp-order-item/excel/upload</b>
+     * <b>POST : API URL => /api/v1/erp-order-items/excel/upload</b>
      * 
      * @param file : MultipartFile
      * @return ResponseEntity(message, HttpStatus)
-     * @throws NullPointerException
-     * @throws IllegalStateException
-     * @throws IllegalArgumentException
      * @see ErpOrderItemBusinessService#isExcelFile
      * @see ErpOrderItemBusinessService#uploadErpOrderExcel
      */
@@ -64,17 +61,17 @@ public class ErpOrderItemApi {
     /**
      * Store excel data for order excel.
      * <p>
-     * <b>POST : API URL => /api/v1/erp-order-item/list</b>
+     * <b>POST : API URL => /api/v1/erp-order-items/batch</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#saveList
+     * @see ErpOrderItemBusinessService#createBatch
      */
-    @PostMapping("/list")
-    public ResponseEntity<?> saveList(@RequestBody @Valid List<ErpOrderItemDto> itemDtos) {
+    @PostMapping("/batch")
+    public ResponseEntity<?> createBatch(@RequestBody @Valid List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
-        erpOrderItemBusinessService.saveList(itemDtos);
+        erpOrderItemBusinessService.createBatch(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
@@ -84,17 +81,17 @@ public class ErpOrderItemApi {
     /**
      * Search erp order item.
      * <p>
-     * <b>GET : API URL => /api/v1/erp-order-item/list</b>
+     * <b>GET : API URL => /api/v1/erp-order-items/products/product-categories</b>
      * 
      * @param params : Map::String, Object::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#searchList
+     * @see ErpOrderItemBusinessService#searchBatch
      */
-    @GetMapping("/list")
-    public ResponseEntity<?> searchList(@RequestParam Map<String, Object> params) {
+    @GetMapping("/products/product-categories")
+    public ResponseEntity<?> searchBatch(@RequestParam Map<String, Object> params) {
         Message message = new Message();
 
-        message.setData(erpOrderItemBusinessService.searchList(params));
+        message.setData(erpOrderItemBusinessService.searchBatch(params));
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
@@ -102,19 +99,19 @@ public class ErpOrderItemApi {
     }
 
     /**
-     * Change erp order item to sales item.
+     * Change salesYn of erp order item.
      * <p>
-     * <b>PATCH : API URL => /api/v1/erp-order-item/list/sales-yn/sales</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-items/batch/sales-yn</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#changeListToSales
+     * @see ErpOrderItemBusinessService#changeBatchForSalesYn
      */
-    @PatchMapping("/list/sales-yn/sales")
-    public ResponseEntity<?> changeListToSales(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    @PatchMapping("/batch/sales-yn")
+    public ResponseEntity<?> changeBatchForSalesYn(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
-        erpOrderItemBusinessService.changeListToSales(itemDtos);
+        erpOrderItemBusinessService.changeBatchForSalesYn(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
@@ -122,59 +119,19 @@ public class ErpOrderItemApi {
     }
 
     /**
-     * Change erp order item to sales item.
+     * Change releaseYn of erp order item.
      * <p>
-     * <b>PATCH : API URL => /api/v1/erp-order-item/list/sales-yn/cancel</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-items/batch/release-yn</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#changeListToSalesCancel
+     * @see ErpOrderItemBusinessService#changeBatchForReleaseYn
      */
-    @PatchMapping("/list/sales-yn/cancel")
-    public ResponseEntity<?> changeListToSalesCancel(@RequestBody List<ErpOrderItemDto> itemDtos) {
-        Message message = new Message();
-
-        erpOrderItemBusinessService.changeListToSalesCancel(itemDtos);
-        message.setStatus(HttpStatus.OK);
-        message.setMessage("success");
-
-        return new ResponseEntity<>(message, message.getStatus());
-    }
-
-    /**
-     * Change erp order item to release item.
-     * <p>
-     * <b>PATCH : API URL => /api/v1/erp-order-item/list/release-yn/release</b>
-     * 
-     * @param itemDtos : List::ErpOrderItemDto::
-     * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#changeListToRelease
-     */
-    @PatchMapping("/list/release-yn/release")
-    public ResponseEntity<?> changeListToRelease(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    @PatchMapping("/batch/release-yn")
+    public ResponseEntity<?> changeBatchForReleaseYn(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
  
-        erpOrderItemBusinessService.changeListToRelease(itemDtos);
-        message.setStatus(HttpStatus.OK);
-        message.setMessage("success");
-
-        return new ResponseEntity<>(message, message.getStatus());
-    }
-
-    /**
-     * Change erp order item to release item.
-     * <p>
-     * <b>PATCH : API URL => /api/v1/erp-order-item/list/release-yn/cancel</b>
-     * 
-     * @param itemDtos : List::ErpOrderItemDto::
-     * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#changeListToReleaseCancel
-     */
-    @PatchMapping("/list/release-yn/cancel")
-    public ResponseEntity<?> changeListToReleaseCancel(@RequestBody List<ErpOrderItemDto> itemDtos) {
-        Message message = new Message();
- 
-        erpOrderItemBusinessService.changeListToReleaseCancel(itemDtos);
+        erpOrderItemBusinessService.changeBatchForReleaseYn(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
@@ -184,13 +141,13 @@ public class ErpOrderItemApi {
     /**
      * Get combined delivery item of erp order item.
      * <p>
-     * <b>POST : API URL => /api/v1/erp-order-item/combined</b>
+     * <b>POST : API URL => /api/v1/erp-order-items/action-combined</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
      * @see ErpOrderItemBusinessService#getCombinedDelivery
      */
-    @PostMapping("/combined")
+    @PostMapping("/action-combined")
     public ResponseEntity<?> getCombinedDelivery(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
@@ -204,13 +161,13 @@ public class ErpOrderItemApi {
     /**
      * Get merged combined delivery item of erp order item.
      * <p>
-     * <b>POST : API URL => /api/v1/erp-order-item/combined/merge</b>
+     * <b>POST : API URL => /api/v1/erp-order-items/action-combined/action-merge</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
      * @see ErpOrderItemBusinessService#getMergeCombinedDelivery
      */
-    @PostMapping("/combined/merge")
+    @PostMapping("/action-combined/action-merge")
     public ResponseEntity<?> getMergeCombinedDelivery(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
@@ -224,39 +181,57 @@ public class ErpOrderItemApi {
     /**
      * Delete erp order item.
      * <p>
-     * <b>POST : API URL => /api/v1/erp-order-item/list/delete</b>
+     * <b>POST : API URL => /api/v1/erp-order-items/batch-delete</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#deleteList
+     * @see ErpOrderItemBusinessService#deleteBatch
      */
-    @PostMapping("/list/delete")
-    public ResponseEntity<?> deleteList(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    @PostMapping("/batch-delete")
+    public ResponseEntity<?> deleteBatch(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
-        erpOrderItemBusinessService.deleteList(itemDtos);
+        erpOrderItemBusinessService.deleteBatch(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
         return new ResponseEntity<>(message, message.getStatus());
     }
 
-    @PatchMapping("/list/option-code/all")
-    public ResponseEntity<?> changeAllOptionCode(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    /**
+     * Change option code and release option code of erp order item.
+     * <p>
+     * <b>Pathch : API URL => /api/v1/erp-order-items/batch/option-code/all</b>
+     * 
+     * @param itemDtos : List::ErpOrderItemDto::
+     * @return ResponseEntity(message, HttpStatus)
+     * @see ErpOrderItemBusinessService#changeBatchForAllOptionCode
+     */
+    @PatchMapping("/batch/option-code/all")
+    public ResponseEntity<?> changeBatchForAllOptionCode(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
-        erpOrderItemBusinessService.changeAllOptionCode(itemDtos);
+        erpOrderItemBusinessService.changeBatchForAllOptionCode(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
         return new ResponseEntity<>(message, message.getStatus());
     }
 
-    @PatchMapping("/list/option-code/release")
-    public ResponseEntity<?> changeReleaseOptionCode(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    /**
+     * Change release option code of erp order item.
+     * <p>
+     * <b>Patch : API URL => /api/v1/erp-order-items/batch/option-code/release</b>
+     * 
+     * @param itemDtos : List::ErpOrderItemDto::
+     * @return ResponseEntity(message, HttpStatus)
+     * @see ErpOrderItemBusinessService#changeBatchForReleaseOptionCode
+     */
+    @PatchMapping("/batch/option-code/release")
+    public ResponseEntity<?> changeBatchForReleaseOptionCode(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
-        erpOrderItemBusinessService.changeReleaseOptionCode(itemDtos);
+        erpOrderItemBusinessService.changeBatchForReleaseOptionCode(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
@@ -102,19 +102,19 @@ public class ErpOrderItemApi {
     }
 
     /**
-     * Update erp order item to sales item.
+     * Change erp order item to sales item.
      * <p>
-     * <b>PATCH : API URL => /api/v1/erp-order-item/sales</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-item/list/sales-yn/sales</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#updateListToSales
+     * @see ErpOrderItemBusinessService#changeListToSales
      */
-    @PatchMapping("/sales")
-    public ResponseEntity<?> updateListToSales(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    @PatchMapping("/list/sales-yn/sales")
+    public ResponseEntity<?> changeListToSales(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
-        erpOrderItemBusinessService.updateListToSales(itemDtos);
+        erpOrderItemBusinessService.changeListToSales(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
@@ -122,19 +122,19 @@ public class ErpOrderItemApi {
     }
 
     /**
-     * Update erp order item to sales item.
+     * Change erp order item to sales item.
      * <p>
-     * <b>PATCH : API URL => /api/v1/erp-order-item/sales/cancel</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-item/list/sales-yn/cancel</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#updateListToSalesCancel
+     * @see ErpOrderItemBusinessService#changeListToSalesCancel
      */
-    @PatchMapping("/sales/cancel")
-    public ResponseEntity<?> updateListToSalesCancel(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    @PatchMapping("/list/sales-yn/cancel")
+    public ResponseEntity<?> changeListToSalesCancel(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
-        erpOrderItemBusinessService.updateListToSalesCancel(itemDtos);
+        erpOrderItemBusinessService.changeListToSalesCancel(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
@@ -142,19 +142,19 @@ public class ErpOrderItemApi {
     }
 
     /**
-     * Update erp order item to release item.
+     * Change erp order item to release item.
      * <p>
-     * <b>PATCH : API URL => /api/v1/erp-order-item/release</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-item/list/release-yn/release</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#updateListToRelease
+     * @see ErpOrderItemBusinessService#changeListToRelease
      */
-    @PatchMapping("/release")
-    public ResponseEntity<?> updateListToRelease(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    @PatchMapping("/list/release-yn/release")
+    public ResponseEntity<?> changeListToRelease(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
  
-        erpOrderItemBusinessService.updateListToRelease(itemDtos);
+        erpOrderItemBusinessService.changeListToRelease(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
@@ -162,19 +162,19 @@ public class ErpOrderItemApi {
     }
 
     /**
-     * Update erp order item to release item.
+     * Change erp order item to release item.
      * <p>
-     * <b>PATCH : API URL => /api/v1/erp-order-item/release/cancel</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-item/list/release-yn/cancel</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
-     * @see ErpOrderItemBusinessService#updateListToReleaseCancel
+     * @see ErpOrderItemBusinessService#changeListToReleaseCancel
      */
-    @PatchMapping("/release/cancel")
-    public ResponseEntity<?> updateListToReleaseCancel(@RequestBody List<ErpOrderItemDto> itemDtos) {
+    @PatchMapping("/list/release-yn/cancel")
+    public ResponseEntity<?> changeListToReleaseCancel(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
  
-        erpOrderItemBusinessService.updateListToReleaseCancel(itemDtos);
+        erpOrderItemBusinessService.changeListToReleaseCancel(itemDtos);
         message.setStatus(HttpStatus.OK);
         message.setMessage("success");
 
@@ -240,6 +240,26 @@ public class ErpOrderItemApi {
 
         return new ResponseEntity<>(message, message.getStatus());
     }
-    
 
+    @PatchMapping("/list/option-code/all")
+    public ResponseEntity<?> changeAllOptionCode(@RequestBody List<ErpOrderItemDto> itemDtos) {
+        Message message = new Message();
+
+        erpOrderItemBusinessService.changeAllOptionCode(itemDtos);
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
+    @PatchMapping("/list/option-code/release")
+    public ResponseEntity<?> changeReleaseOptionCode(@RequestBody List<ErpOrderItemDto> itemDtos) {
+        Message message = new Message();
+
+        erpOrderItemBusinessService.changeReleaseOptionCode(itemDtos);
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
 }

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemApi.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -103,13 +104,13 @@ public class ErpOrderItemApi {
     /**
      * Update erp order item to sales item.
      * <p>
-     * <b>PUT : API URL => /api/v1/erp-order-item/sales</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-item/sales</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
      * @see ErpOrderItemBusinessService#updateListToSales
      */
-    @PutMapping("/sales")
+    @PatchMapping("/sales")
     public ResponseEntity<?> updateListToSales(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
@@ -123,13 +124,13 @@ public class ErpOrderItemApi {
     /**
      * Update erp order item to sales item.
      * <p>
-     * <b>PUT : API URL => /api/v1/erp-order-item/sales/cancel</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-item/sales/cancel</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
      * @see ErpOrderItemBusinessService#updateListToSalesCancel
      */
-    @PutMapping("/sales/cancel")
+    @PatchMapping("/sales/cancel")
     public ResponseEntity<?> updateListToSalesCancel(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
 
@@ -143,13 +144,13 @@ public class ErpOrderItemApi {
     /**
      * Update erp order item to release item.
      * <p>
-     * <b>PUT : API URL => /api/v1/erp-order-item/release</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-item/release</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
      * @see ErpOrderItemBusinessService#updateListToRelease
      */
-    @PutMapping("/release")
+    @PatchMapping("/release")
     public ResponseEntity<?> updateListToRelease(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
  
@@ -163,13 +164,13 @@ public class ErpOrderItemApi {
     /**
      * Update erp order item to release item.
      * <p>
-     * <b>PUT : API URL => /api/v1/erp-order-item/release/cancel</b>
+     * <b>PATCH : API URL => /api/v1/erp-order-item/release/cancel</b>
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @return ResponseEntity(message, HttpStatus)
      * @see ErpOrderItemBusinessService#updateListToReleaseCancel
      */
-    @PutMapping("/release/cancel")
+    @PatchMapping("/release/cancel")
     public ResponseEntity<?> updateListToReleaseCancel(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();
  

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/dto/ErpOrderItemDto.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/dto/ErpOrderItemDto.java
@@ -157,6 +157,9 @@ public class ErpOrderItemDto {
     private String salesYn;
     
     private LocalDateTime salesAt;
+
+    @Size(max = 20)
+    private String releaseOptionCode;
     
     @Size(max = 1)
     private String releaseYn;
@@ -224,6 +227,7 @@ public class ErpOrderItemDto {
                 .managementMemo20(entity.getManagementMemo20())
                 .salesYn(entity.getSalesYn())
                 .salesAt(entity.getSalesAt())
+                .releaseOptionCode(entity.getReleaseOptionCode())
                 .releaseYn(entity.getReleaseYn())
                 .releaseAt(entity.getReleaseAt())
                 .stockReflectYn(entity.getStockReflectYn())

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/entity/ErpOrderItemEntity.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/entity/ErpOrderItemEntity.java
@@ -98,6 +98,7 @@ public class ErpOrderItemEntity {
     @Column(name = "prod_code")
     private String prodCode; // 피아르 상품코드
 
+    @Setter
     @Column(name = "option_code")
     private String optionCode; // 피아르 옵션코드
 
@@ -170,6 +171,10 @@ public class ErpOrderItemEntity {
     private LocalDateTime salesAt;
 
     @Setter
+    @Column(name = "release_option_code")
+    private String releaseOptionCode;
+
+    @Setter
     @Column(name = "release_yn", columnDefinition = "n")
     private String releaseYn;
 
@@ -236,6 +241,7 @@ public class ErpOrderItemEntity {
                 .managementMemo20(dto.getManagementMemo20())
                 .salesYn(dto.getSalesYn())
                 .salesAt(dto.getSalesAt())
+                .releaseOptionCode(dto.getReleaseOptionCode())
                 .releaseYn(dto.getReleaseYn())
                 .releaseAt(dto.getReleaseAt())
                 .createdAt(dto.getCreatedAt())

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/repository/ErpOrderItemRepository.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/repository/ErpOrderItemRepository.java
@@ -1,5 +1,6 @@
 package com.piaar_erp.erp_api.domain.erp_order_item.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemBusinessService.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemBusinessService.java
@@ -21,6 +21,7 @@ import com.piaar_erp.erp_api.domain.erp_order_header.service.ErpOrderHeaderServi
 import com.piaar_erp.erp_api.domain.erp_order_item.dto.ErpOrderItemDto;
 import com.piaar_erp.erp_api.domain.erp_order_item.entity.ErpOrderItemEntity;
 import com.piaar_erp.erp_api.domain.erp_order_item.proj.ErpOrderItemProj;
+import com.piaar_erp.erp_api.domain.erp_order_item.repository.ErpOrderItemRepository;
 import com.piaar_erp.erp_api.domain.erp_order_item.vo.CombinedDeliveryErpOrderItemVo;
 import com.piaar_erp.erp_api.domain.erp_order_item.vo.ErpOrderItemVo;
 import com.piaar_erp.erp_api.domain.exception.CustomExcelFileUploadException;
@@ -41,9 +42,6 @@ import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import ch.qos.logback.classic.db.names.ColumnName;
-import java_cup.runtime.lr_parser;
 
 @Service
 public class ErpOrderItemBusinessService {
@@ -260,6 +258,7 @@ public class ErpOrderItemBusinessService {
                     r.setId(UUID.randomUUID())
                             .setUniqueCode(UUID.randomUUID().toString())
                             .setSalesYn("n")
+                            .setReleaseOptionCode(r.getOptionCode())
                             .setReleaseYn("n")
                             .setStockReflectYn("n")
                             .setCreatedAt(CustomDateUtils.getCurrentDateTime())
@@ -333,7 +332,7 @@ public class ErpOrderItemBusinessService {
      * @see CustomDateUtils#getCurrentDateTime
      * @see ErpOrderItemService#saveListAndModify
      */
-    public void updateListToSales(List<ErpOrderItemDto> itemDtos) {
+    public void changeListToSales(List<ErpOrderItemDto> itemDtos) {
         List<UUID> idList = itemDtos.stream().map(dto -> dto.getId()).collect(Collectors.toList());
         List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
 
@@ -353,7 +352,7 @@ public class ErpOrderItemBusinessService {
      * @see ErpOrderItemService#findAllByIdList
      * @see ErpOrderItemService#saveListAndModify
      */
-    public void updateListToSalesCancel(List<ErpOrderItemDto> itemDtos) {
+    public void changeListToSalesCancel(List<ErpOrderItemDto> itemDtos) {
         List<UUID> idList = itemDtos.stream().map(dto -> dto.getId()).collect(Collectors.toList());
         List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
 
@@ -374,7 +373,7 @@ public class ErpOrderItemBusinessService {
      * @see CustomDateUtils#getCurrentDateTime
      * @see ErpOrderItemService#saveListAndModify
      */
-    public void updateListToRelease(List<ErpOrderItemDto> itemDtos) {
+    public void changeListToRelease(List<ErpOrderItemDto> itemDtos) {
         List<UUID> idList = itemDtos.stream().map(dto -> dto.getId()).collect(Collectors.toList());
         List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
 
@@ -394,7 +393,7 @@ public class ErpOrderItemBusinessService {
      * @see ErpOrderItemService#findAllByIdList
      * @see ErpOrderItemService#saveListAndModify
      */
-    public void updateListToReleaseCancel(List<ErpOrderItemDto> itemDtos) {
+    public void changeListToReleaseCancel(List<ErpOrderItemDto> itemDtos) {
         List<UUID> idList = itemDtos.stream().map(dto -> dto.getId()).collect(Collectors.toList());
         List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
 
@@ -522,6 +521,24 @@ public class ErpOrderItemBusinessService {
         itemDtos.stream().forEach(dto -> {
             ErpOrderItemEntity.toEntity(dto);
             erpOrderItemService.delete(dto.getId());
+        });
+    }
+
+    public void changeAllOptionCode(List<ErpOrderItemDto> itemDtos) {
+        itemDtos.stream().forEach(dto -> {
+            ErpOrderItemEntity entity = erpOrderItemService.searchOne(dto.getId());
+            entity.setOptionCode(dto.getOptionCode()).setReleaseOptionCode(dto.getOptionCode());
+
+            erpOrderItemService.saveAndModify(entity);
+        });
+    }
+
+    public void changeReleaseOptionCode(List<ErpOrderItemDto> itemDtos) {
+        itemDtos.stream().forEach(dto -> {
+            ErpOrderItemEntity entity = erpOrderItemService.searchOne(dto.getId());
+            entity.setReleaseOptionCode(dto.getReleaseOptionCode());
+
+            erpOrderItemService.saveAndModify(entity);
         });
     }
 }

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemBusinessService.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemBusinessService.java
@@ -250,7 +250,7 @@ public class ErpOrderItemBusinessService {
         return itemVos;
     }
 
-    public void saveList(List<ErpOrderItemDto> orderItemDtos) {
+    public void createBatch(List<ErpOrderItemDto> orderItemDtos) {
         UUID USER_ID = UUID.randomUUID();
 
         List<ErpOrderItemEntity> orderItemEntities = orderItemDtos.stream()
@@ -279,13 +279,13 @@ public class ErpOrderItemBusinessService {
      * @param params : Map::String, Object::
      * @return List::ErpOrderItemVo::
      * @see ErpOrderItemService#findAllM2OJ
-     * @see ErpOrderItemBusinessService#getOptionStockUnit
+     * @see ErpOrderItemBusinessService#setOptionStockUnit
      */
-    public List<ErpOrderItemVo> searchList(Map<String, Object> params) {
+    public List<ErpOrderItemVo> searchBatch(Map<String, Object> params) {
         // 등록된 모든 엑셀 데이터를 조회한다
         List<ErpOrderItemProj> itemProjs = erpOrderItemService.findAllM2OJ(params);
         // 옵션재고수량 추가
-        List<ErpOrderItemVo> ErpOrderItemVos = this.getOptionStockUnit(itemProjs);
+        List<ErpOrderItemVo> ErpOrderItemVos = this.setOptionStockUnit(itemProjs);
         return ErpOrderItemVos;
     }
 
@@ -300,7 +300,7 @@ public class ErpOrderItemBusinessService {
      * @see ProductOptionService#searchStockUnit
      * @see ErpOrderItemVo#toVo
      */
-    public List<ErpOrderItemVo> getOptionStockUnit(List<ErpOrderItemProj> itemProjs) {
+    public List<ErpOrderItemVo> setOptionStockUnit(List<ErpOrderItemProj> itemProjs) {
         // 옵션이 존재하는 데이터들의 
         List<ProductOptionEntity> optionEntities = itemProjs.stream().filter(r -> r.getProductOption() != null ? true : false).collect(Collectors.toList())
             .stream().map(r -> r.getProductOption()).collect(Collectors.toList());
@@ -325,19 +325,23 @@ public class ErpOrderItemBusinessService {
     /**
      * <b>DB Update Related Method</b>
      * <p>
-     * 엑셀 데이터의 salesYn(판매 여부)을 y(판매 O)로 업데이트한다.
+     * 엑셀 데이터의 salesYn(판매 여부)을 업데이트한다.
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @see ErpOrderItemService#findAllByIdList
      * @see CustomDateUtils#getCurrentDateTime
      * @see ErpOrderItemService#saveListAndModify
      */
-    public void changeListToSales(List<ErpOrderItemDto> itemDtos) {
+    public void changeBatchForSalesYn(List<ErpOrderItemDto> itemDtos) {
         List<UUID> idList = itemDtos.stream().map(dto -> dto.getId()).collect(Collectors.toList());
         List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
 
         entities.forEach(entity -> {
-            entity.setSalesYn("y").setSalesAt(CustomDateUtils.getCurrentDateTime());
+            itemDtos.forEach(dto -> {
+                if(entity.getId().equals(dto.getId())){
+                    entity.setSalesYn(dto.getSalesYn()).setSalesAt(dto.getSalesAt());
+                }
+            });
         });
 
         erpOrderItemService.saveListAndModify(entities);
@@ -346,59 +350,23 @@ public class ErpOrderItemBusinessService {
     /**
      * <b>DB Update Related Method</b>
      * <p>
-     * 엑셀 데이터의 salesYn(판매 여부)을 n(판매 X)로 업데이트한다.
-     * 
-     * @param itemDtos : List::ErpOrderItemDto::
-     * @see ErpOrderItemService#findAllByIdList
-     * @see ErpOrderItemService#saveListAndModify
-     */
-    public void changeListToSalesCancel(List<ErpOrderItemDto> itemDtos) {
-        List<UUID> idList = itemDtos.stream().map(dto -> dto.getId()).collect(Collectors.toList());
-        List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
-
-        entities.forEach(entity -> {
-            entity.setSalesYn("n").setSalesAt(null);
-        });
-
-        erpOrderItemService.saveListAndModify(entities);
-    }
-
-    /**
-     * <b>DB Update Related Method</b>
-     * <p>
-     * 엑셀 데이터의 releaseYn(출고 여부)을 y(출고 O)로 업데이트한다.
+     * 엑셀 데이터의 releaseYn(출고 여부)을 업데이트한다.
      * 
      * @param itemDtos : List::ErpOrderItemDto::
      * @see ErpOrderItemService#findAllByIdList
      * @see CustomDateUtils#getCurrentDateTime
      * @see ErpOrderItemService#saveListAndModify
      */
-    public void changeListToRelease(List<ErpOrderItemDto> itemDtos) {
+    public void changeBatchForReleaseYn(List<ErpOrderItemDto> itemDtos) {
         List<UUID> idList = itemDtos.stream().map(dto -> dto.getId()).collect(Collectors.toList());
         List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
 
         entities.forEach(entity -> {
-            entity.setReleaseYn("y").setReleaseAt(CustomDateUtils.getCurrentDateTime());
-        });
-
-        erpOrderItemService.saveListAndModify(entities);
-    }
-
-    /**
-     * <b>DB Update Related Method</b>
-     * <p>
-     * 엑셀 데이터의 releaseYn(출고 여부)을 n(출고 X)로 업데이트한다.
-     * 
-     * @param itemDtos : List::ErpOrderItemDto::
-     * @see ErpOrderItemService#findAllByIdList
-     * @see ErpOrderItemService#saveListAndModify
-     */
-    public void changeListToReleaseCancel(List<ErpOrderItemDto> itemDtos) {
-        List<UUID> idList = itemDtos.stream().map(dto -> dto.getId()).collect(Collectors.toList());
-        List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
-
-        entities.forEach(entity -> {
-            entity.setReleaseYn("n").setReleaseAt(null);
+            itemDtos.forEach(dto -> {
+                if(entity.getId().equals(dto.getId())){
+                    entity.setReleaseYn(dto.getReleaseYn()).setReleaseAt(dto.getReleaseAt());
+                }
+            });
         });
 
         erpOrderItemService.saveListAndModify(entities);
@@ -517,28 +485,56 @@ public class ErpOrderItemBusinessService {
      * @see ErpOrderItemEntity#toEntity
      * @see ErpOrderItemService#delete
      */
-    public void deleteList(List<ErpOrderItemDto> itemDtos) {
+    public void deleteBatch(List<ErpOrderItemDto> itemDtos) {
         itemDtos.stream().forEach(dto -> {
             ErpOrderItemEntity.toEntity(dto);
             erpOrderItemService.delete(dto.getId());
         });
     }
 
-    public void changeAllOptionCode(List<ErpOrderItemDto> itemDtos) {
-        itemDtos.stream().forEach(dto -> {
-            ErpOrderItemEntity entity = erpOrderItemService.searchOne(dto.getId());
-            entity.setOptionCode(dto.getOptionCode()).setReleaseOptionCode(dto.getOptionCode());
+    /**
+     * <b>Data Update Related Method</b>
+     * <p>
+     * 변경 주문 옵션코드를 참고해 주문 옵션코드와 출고 옵션코드를 변경한다.
+     * 
+     * @param itemDtos : List::ErpOrderItemDto::
+     * @see ErpOrderItemService#findAllByIdList
+     * @see ErpOrderItemService#saveListAndModify
+     */
+    public void changeBatchForAllOptionCode(List<ErpOrderItemDto> itemDtos) {
+        List<UUID> idList = itemDtos.stream().map(r -> r.getId()).collect(Collectors.toList());
+        List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
 
-            erpOrderItemService.saveAndModify(entity);
+        entities.stream().forEach(entity -> {
+            itemDtos.stream().forEach(dto -> {
+                if(entity.getId().equals(dto.getId())) {
+                    entity.setOptionCode(dto.getOptionCode()).setReleaseOptionCode(dto.getOptionCode());
+                }
+            });
         });
+        erpOrderItemService.saveListAndModify(entities);
     }
 
-    public void changeReleaseOptionCode(List<ErpOrderItemDto> itemDtos) {
-        itemDtos.stream().forEach(dto -> {
-            ErpOrderItemEntity entity = erpOrderItemService.searchOne(dto.getId());
-            entity.setReleaseOptionCode(dto.getReleaseOptionCode());
+    /**
+     * <b>Data Update Related Method</b>
+     * <p>
+     * 출고 옵션코드를 변경한다.
+     * 
+     * @param itemDtos : List::ErpOrderItemDto::
+     * @see ErpOrderItemService#findAllByIdList
+     * @see ErpOrderItemService#saveListAndModify
+     */
+    public void changeBatchForReleaseOptionCode(List<ErpOrderItemDto> itemDtos) {
+        List<UUID> idList = itemDtos.stream().map(r -> r.getId()).collect(Collectors.toList());
+        List<ErpOrderItemEntity> entities = erpOrderItemService.findAllByIdList(idList);
 
-            erpOrderItemService.saveAndModify(entity);
+        entities.stream().forEach(entity -> {
+            itemDtos.stream().forEach(dto -> {
+                if(entity.getId().equals(dto.getId())) {
+                    entity.setReleaseOptionCode(dto.getReleaseOptionCode());
+                }
+            });
         });
+        erpOrderItemService.saveListAndModify(entities);
     }
 }

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemService.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemService.java
@@ -2,11 +2,13 @@ package com.piaar_erp.erp_api.domain.erp_order_item.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import com.piaar_erp.erp_api.domain.erp_order_item.entity.ErpOrderItemEntity;
 import com.piaar_erp.erp_api.domain.erp_order_item.proj.ErpOrderItemProj;
 import com.piaar_erp.erp_api.domain.erp_order_item.repository.ErpOrderItemRepository;
+import com.piaar_erp.erp_api.domain.exception.CustomNotFoundDataException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,18 @@ public class ErpOrderItemService {
         ErpOrderItemRepository erpOrderItemRepository
     ) {
         this.erpOrderItemRepository = erpOrderItemRepository;
+    }
+
+    /**
+     * <b>DB Insert Or Update Related Method</b>
+     * <p>
+     * 피아르 엑셀 데이터를 저장 or 수정한다.
+     *
+     * @param itemEntity : ErpOrderItemEntity
+     * @see ErpOrderItemRepository#save
+     */
+    public void saveAndModify(ErpOrderItemEntity itemEntity) {
+        erpOrderItemRepository.save(itemEntity);
     }
 
     /**
@@ -73,5 +87,15 @@ public class ErpOrderItemService {
         erpOrderItemRepository.findById(id).ifPresent(item -> {
             erpOrderItemRepository.delete(item);
         });
+    }
+
+    public ErpOrderItemEntity searchOne(UUID id) {
+        Optional<ErpOrderItemEntity> entityOpt = erpOrderItemRepository.findById(id);
+
+        if(entityOpt.isPresent()){
+            return entityOpt.get();
+        }else{
+            throw new CustomNotFoundDataException("존재하지 않는 데이터입니다.");
+        }
     }
 }

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/vo/ErpOrderItemVo.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/vo/ErpOrderItemVo.java
@@ -68,6 +68,7 @@ public class ErpOrderItemVo {
 
     private String salesYn;
     private LocalDateTime salesAt;
+    private String releaseOptionCode;
     private String releaseYn;
     private LocalDateTime releaseAt;
     private String stockReflectYn;
@@ -119,6 +120,7 @@ public class ErpOrderItemVo {
                 .managementMemo18(proj.getErpOrderItem().getManagementMemo18())
                 .managementMemo19(proj.getErpOrderItem().getManagementMemo19())
                 .managementMemo20(proj.getErpOrderItem().getManagementMemo20())
+                .releaseOptionCode(proj.getErpOrderItem().getReleaseOptionCode())
                 .salesYn(proj.getErpOrderItem().getSalesYn())
                 .salesAt(proj.getErpOrderItem().getSalesAt())
                 .releaseYn(proj.getErpOrderItem().getReleaseYn())


### PR DESCRIPTION
#### [ 변경사항 ]

1)
* 객체의 일부만 변경 시 PUT이 아닌 PATCH 메서드를 사용해서 구현하도록 변경

2)
* 주문 및 출고 옵션코드 변경 기능 추가. 주문 옵션코드가 수정되었을 때, 주문 및 출고 옵션코드가 변경됩니다.
* 출고 옵션코드 변경 기능 추가. 출고 옵션코드가 수정되었을 때, 출고 옵션코드만 변경됩니다.

3)
* 새로 정의한 api명 규칙과 메서드 규칙을 사용해 api명과 메서드명을 변경했습니다.
* 주문 및 출고 옵션코드 변경 코드에서 불필요한 레포지터리 방문을 제거했습니다.
* 판매 및 판매취소 통합, 출고 및 출고취소 통합

-----

#### [ 요청사항 ]

1)

2)
* ~~비즈니스 서비스단에 옵션코드를 수정 구현부분 확인부탁드립니다.~~

3)
* ManyToOne데이터 조회 컨트롤러의 api명을 /api/v1/erp-order-items/products/product-categories로 변경했는데, 이 컨트롤러에서 ManyToOne데이터를 조회하지만 vo로 뿌려줄때는 erp-order-item에 ManyToOne 데이터들을 삽입해 전달합니다. 이 경우에도 위와 같은 api명을 사용하는게 맞나요?? 확인부탁드립니다
* salesYn과 releaseYn설정 변경 로직이 변경되면서, 만약 판매 처리 시에는 dto에 salesYn-(y), salesAt-(date)을 설정해줘야하고 판매 취소처리 시에는 dto에 salesYn-(n), salesAt -(null)로 설정해줘야 합니다.

-----