### PR TITLE
FEAT : 재고 반영 기능 추가함.

### DIFF
--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemSocket.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/controller/ErpOrderItemSocket.java
@@ -103,6 +103,17 @@ public class ErpOrderItemSocket {
         messagingTemplate.convertAndSend("/topic/erp.erp-order-item", message);
     }
 
+    @PatchMapping("/batch/stock/action-reflect")
+    public ResponseEntity<?> actionReflectStock(@RequestBody List<ErpOrderItemDto> itemDtos){
+        Message message = new Message();
+
+        System.out.println(erpOrderItemBusinessService.actionReflectStock(itemDtos));
+        message.setStatus(HttpStatus.OK);
+        message.setMessage("success");
+
+        return new ResponseEntity<>(message, message.getStatus());
+    }
+
     @PostMapping("/batch-delete")
     public void deleteBatch(@RequestBody List<ErpOrderItemDto> itemDtos) {
         Message message = new Message();

--- a/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemService.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/erp_order_item/service/ErpOrderItemService.java
@@ -4,9 +4,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.transaction.Transactional;
 
+import com.piaar_erp.erp_api.domain.erp_order_item.dto.ErpOrderItemDto;
 import com.piaar_erp.erp_api.domain.erp_order_item.entity.ErpOrderItemEntity;
 import com.piaar_erp.erp_api.domain.erp_order_item.proj.ErpOrderItemProj;
 import com.piaar_erp.erp_api.domain.erp_order_item.repository.ErpOrderItemRepository;
@@ -55,7 +57,6 @@ public class ErpOrderItemService {
      *
      * @return List::ErpOrderItemProj::
      * @see ErpOrderItemRepository#qfindAllM2OJ
-     * 
      */
     public List<ErpOrderItemProj> findAllM2OJ(Map<String, Object> params) {
         return erpOrderItemRepository.qfindAllM2OJ(params);
@@ -72,7 +73,6 @@ public class ErpOrderItemService {
      *
      * @return List::ErpOrderItemProj::
      * @see ErpOrderItemRepository#qfindAllM2OJ
-     * 
      */
     public Page<ErpOrderItemProj> findAllM2OJByPage(Map<String, Object> params, Pageable pageable) {
         return erpOrderItemRepository.qfindAllM2OJByPage(params, pageable);
@@ -86,7 +86,7 @@ public class ErpOrderItemService {
      * <b>DB Select Related Method</b>
      * <p>
      * id 값들과 대응하는 엑셀 데이터를 모두 조회한다.
-     * 
+     *
      * @param idList : List::UUID::
      * @return List::ErpOrderItemEntity::
      * @see ErpOrderItemRepository#qfindAllByIdList
@@ -99,7 +99,7 @@ public class ErpOrderItemService {
      * <b>DB Delete Related Method</b>
      * <p>
      * id 값에 대응하는 엑셀 데이터를 삭제한다.
-     * 
+     *
      * @param id : UUID
      * @ErpOrderItemRepository#findById
      * @ErpOrderItemRepository#delete
@@ -114,7 +114,7 @@ public class ErpOrderItemService {
      * <b>DB Delete Related Method</b>
      * <p>
      * id 값에 대응하는 엑셀 데이터를 모두 삭제한다.
-     * 
+     *
      * @param ids : List::UUID::
      * @ErpOrderItemRepository#deleteAllById
      */
@@ -125,14 +125,20 @@ public class ErpOrderItemService {
     public ErpOrderItemEntity searchOne(UUID id) {
         Optional<ErpOrderItemEntity> entityOpt = erpOrderItemRepository.findById(id);
 
-        if(entityOpt.isPresent()){
+        if (entityOpt.isPresent()) {
             return entityOpt.get();
-        }else{
+        } else {
             throw new CustomNotFoundDataException("존재하지 않는 데이터입니다.");
         }
     }
 
     public List<ErpOrderItemEntity> findDuplicationItems(List<String> orderNumber1, List<String> receiver, List<String> prodName, List<String> optionName, List<Integer> unit) {
         return erpOrderItemRepository.findDuplicationItems(orderNumber1, receiver, prodName, optionName, unit);
+    }
+
+    public List<ErpOrderItemEntity> getEntities(List<ErpOrderItemDto> itemDtos) {
+        List<UUID> ids = itemDtos.stream().map(r -> r.getId()).collect(Collectors.toList());
+        return erpOrderItemRepository.qfindAllByIdList(ids);
+
     }
 }

--- a/src/main/java/com/piaar_erp/erp_api/domain/product_option/service/ProductOptionService.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/product_option/service/ProductOptionService.java
@@ -68,6 +68,11 @@ public class ProductOptionService {
         return productOptionGetDtos;
     }
 
+    public List<ProductOptionEntity> searchListByOptionCodes(List<String> optionCodes) {
+        List<ProductOptionEntity> productOptionEntities = productOptionRepository.findAllByCode(optionCodes);
+        return productOptionEntities;
+    }
+
     /**
      * <b>DB Select Related Method</b>
      * <p>

--- a/src/main/java/com/piaar_erp/erp_api/domain/release_stock/controller/ReleaseStockSocket.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/release_stock/controller/ReleaseStockSocket.java
@@ -1,0 +1,12 @@
+package com.piaar_erp.erp_api.domain.release_stock.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/wd/v1/release-stocks/")
+public class ReleaseStockSocket {
+}

--- a/src/main/java/com/piaar_erp/erp_api/domain/release_stock/dto/ReleaseStockDto.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/release_stock/dto/ReleaseStockDto.java
@@ -1,0 +1,23 @@
+package com.piaar_erp.erp_api.domain.release_stock.dto;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReleaseStockDto {
+    private Integer cid;
+    private UUID id;
+    private Integer releaseUnit;
+    private String memo;
+    private LocalDateTime createdAt;
+    private UUID createdBy;
+    private Integer productOptionCid;
+    private UUID productOptionId;
+    private UUID erpOrderItemId;
+}

--- a/src/main/java/com/piaar_erp/erp_api/domain/release_stock/entity/ReleaseStockEntity.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/release_stock/entity/ReleaseStockEntity.java
@@ -1,0 +1,51 @@
+package com.piaar_erp.erp_api.domain.release_stock.entity;
+
+import lombok.*;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "release_stock")
+public class ReleaseStockEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cid")
+    private Integer cid;
+
+    @Column(name = "id")
+    @Type(type = "uuid-char")
+    private UUID id;
+
+    @Column(name = "release_unit")
+    private Integer releaseUnit;
+
+    @Column(name = "memo")
+    private String memo;
+
+    @Column(name="created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by")
+    @Type(type ="uuid-char")
+    private UUID createdBy;
+
+    @Column(name = "product_option_cid")
+    private Integer productOptionCid;
+
+    @Column(name = "product_option_id")
+    @Type(type ="uuid-char")
+    private UUID productOptionId;
+
+    @Column(name = "erp_order_item_id")
+    @Type(type ="uuid-char")
+    private UUID erpOrderItemId;
+}

--- a/src/main/java/com/piaar_erp/erp_api/domain/release_stock/repository/ReleaseStockCustomJdbc.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/release_stock/repository/ReleaseStockCustomJdbc.java
@@ -1,0 +1,11 @@
+package com.piaar_erp.erp_api.domain.release_stock.repository;
+
+import com.piaar_erp.erp_api.domain.release_stock.entity.ReleaseStockEntity;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReleaseStockCustomJdbc {
+    void jdbcBulkInsert(List<ReleaseStockEntity> entities);
+}

--- a/src/main/java/com/piaar_erp/erp_api/domain/release_stock/repository/ReleaseStockJdbcImpl.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/release_stock/repository/ReleaseStockJdbcImpl.java
@@ -1,0 +1,70 @@
+package com.piaar_erp.erp_api.domain.release_stock.repository;
+
+import com.piaar_erp.erp_api.domain.release_stock.entity.ReleaseStockEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class ReleaseStockJdbcImpl implements ReleaseStockCustomJdbc{
+    private final JdbcTemplate jdbcTemplate;
+    private int batchSize = 300;
+
+    @Override
+    public void jdbcBulkInsert(List<ReleaseStockEntity> entities){
+        int batchCount = 0;
+        List<ReleaseStockEntity> subItems = new ArrayList<>();
+        for (int i = 0; i < entities.size(); i++) {
+            subItems.add(entities.get(i));
+            if ((i + 1) % batchSize == 0) {
+                batchCount = batchInsert(batchSize, batchCount, subItems);
+            }
+        }
+        if (!subItems.isEmpty()) {
+            batchCount = batchInsert(batchSize, batchCount, subItems);
+        }
+//        log.info("batchCount: " + batchCount);
+    }
+
+    private int batchInsert(int batchSize, int batchCount, List<ReleaseStockEntity> subItems){
+        String sql = "INSERT INTO release_stock" +
+                "(cid, id, release_unit, memo, created_at, created_by, product_option_cid, product_option_id, erp_order_item_id)" +
+                "VALUES" +
+                "(NULL, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ReleaseStockEntity entity = subItems.get(i);
+                ps.setObject(1, entity.getId().toString());
+                ps.setInt(2, entity.getReleaseUnit());
+                ps.setString(3, entity.getMemo());
+                ps.setObject(4, entity.getCreatedAt());
+                ps.setObject(5, entity.getCreatedBy().toString());
+                ps.setInt(6, entity.getProductOptionCid());
+                ps.setObject(7, entity.getProductOptionId().toString());
+                ps.setObject(8, entity.getErpOrderItemId().toString());
+
+            }
+
+            @Override
+            public int getBatchSize() {
+                return subItems.size();
+            }
+        });
+
+        subItems.clear();
+        batchCount++;
+        return batchCount;
+    }
+
+}

--- a/src/main/java/com/piaar_erp/erp_api/domain/release_stock/repository/ReleaseStockRepository.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/release_stock/repository/ReleaseStockRepository.java
@@ -1,0 +1,9 @@
+package com.piaar_erp.erp_api.domain.release_stock.repository;
+
+import com.piaar_erp.erp_api.domain.release_stock.entity.ReleaseStockEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReleaseStockRepository extends JpaRepository<ReleaseStockEntity, Integer>{
+}

--- a/src/main/java/com/piaar_erp/erp_api/domain/release_stock/service/ReleaseStockService.java
+++ b/src/main/java/com/piaar_erp/erp_api/domain/release_stock/service/ReleaseStockService.java
@@ -1,0 +1,25 @@
+package com.piaar_erp.erp_api.domain.release_stock.service;
+
+import com.piaar_erp.erp_api.domain.release_stock.repository.ReleaseStockCustomJdbc;
+import com.piaar_erp.erp_api.domain.release_stock.repository.ReleaseStockJdbcImpl;
+import com.piaar_erp.erp_api.domain.release_stock.repository.ReleaseStockRepository;
+import com.piaar_erp.erp_api.domain.release_stock.entity.ReleaseStockEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReleaseStockService {
+    private final ReleaseStockRepository releaseStockRepository;
+    private final ReleaseStockCustomJdbc releaseStockCustomJdbc;
+
+    public void saveAndModifyList(List<ReleaseStockEntity> entities) {
+        releaseStockRepository.saveAll(entities);
+    }
+
+    public void bulkInsert(List<ReleaseStockEntity> entities){
+        releaseStockCustomJdbc.jdbcBulkInsert(entities);
+    }
+}


### PR DESCRIPTION
기존에 product_release 테이블이 있지만 우선 구조가 조금 변경되어야 될것 같아서 release_stock이라는 테이블로 생성했고, ReleaseStockEntity 구성 후 재고 반영 관련 데이터 작업 진행함.
JPA Insert 부분이 300개 정도 데이터가 쌓이면 도저히 감당이 안될정도의 딜레이가 생기는것 같아서 어쩔수 없이 Jdbc 배치 Insert 로 작업하기로 함.
ReleaseStockJdbcImpl, ReleaseStockCustomJdbc 부분이 Jdbc를 이용해서 배치 Insert 쿼리 날리는 레포임.